### PR TITLE
change doc block to fix magento2 swagger

### DIFF
--- a/Api/CheckoutInterface.php
+++ b/Api/CheckoutInterface.php
@@ -34,7 +34,7 @@ interface CheckoutInterface
      *
      * @param string|null $guestEmail Customer E-Mail address.
      *
-     * @return Customer|null
+     * @return \Heidelpay\MGW\Api\Data\Customer|null
      */
     public function getExternalCustomer(?string $guestEmail = null): ?Customer;
 }


### PR DESCRIPTION
Swagger.io requires an absolute URI for the namespace