### PR TITLE
Allow setting the billing address for guaranteed methods

### DIFF
--- a/Model/Command/AbstractCommand.php
+++ b/Model/Command/AbstractCommand.php
@@ -21,7 +21,6 @@ use Magento\Payment\Model\InfoInterface;
 use Magento\Sales\Model\Order as SalesOrder;
 use Magento\Sales\Model\Order\Payment as OrderPayment;
 use Psr\Log\LoggerInterface;
-
 use function get_class;
 
 /**
@@ -149,10 +148,6 @@ abstract class AbstractCommand implements CommandInterface
         $customer = $this->_getClient()->fetchCustomer($customerId);
 
         if (!$this->_orderHelper->validateGatewayCustomerAgainstOrder($order, $customer)) {
-            if ($payment->getMethodInstance()->isGuaranteed()) {
-                throw new LocalizedException(__('Payment information does not match billing address.'));
-            }
-
             $this->_orderHelper->updateGatewayCustomerFromOrder($order, $customer);
         }
 

--- a/Model/Method/Base.php
+++ b/Model/Method/Base.php
@@ -162,16 +162,6 @@ class Base extends Adapter
     }
 
     /**
-     * Returns whether the payment method is safe.
-     *
-     * @return bool
-     */
-    public function isGuaranteed(): bool
-    {
-        return false;
-    }
-
-    /**
      * {@inheritDoc}
      */
     public function getTitle()

--- a/Model/Method/DirectDebitGuaranteed.php
+++ b/Model/Method/DirectDebitGuaranteed.php
@@ -34,12 +34,4 @@ class DirectDebitGuaranteed extends DirectDebit
     {
         return true;
     }
-
-    /**
-     * @return bool
-     */
-    public function isGuaranteed(): bool
-    {
-        return true;
-    }
 }

--- a/Model/Method/InvoiceGuaranteed.php
+++ b/Model/Method/InvoiceGuaranteed.php
@@ -34,12 +34,4 @@ class InvoiceGuaranteed extends Invoice
     {
         return true;
     }
-
-    /**
-     * @return bool
-     */
-    public function isGuaranteed(): bool
-    {
-        return true;
-    }
 }

--- a/Model/Method/InvoiceGuaranteedB2b.php
+++ b/Model/Method/InvoiceGuaranteedB2b.php
@@ -34,12 +34,4 @@ class InvoiceGuaranteedB2b extends Invoice
     {
         return true;
     }
-
-    /**
-     * @return bool
-     */
-    public function isGuaranteed(): bool
-    {
-        return true;
-    }
 }

--- a/view/frontend/web/template/payment/direct_debit_guaranteed.html
+++ b/view/frontend/web/template/payment/direct_debit_guaranteed.html
@@ -10,6 +10,12 @@
         <label class="label" data-bind="attr: {'for': getCode()}"><span data-bind="text: getTitle()"></span></label>
     </div>
     <div class="payment-method-content">
+        <div class="payment-method-billing-address">
+            <!-- ko foreach: $parent.getRegion(getBillingAddressFormName()) -->
+            <!-- ko template: getTemplate() --><!-- /ko -->
+            <!--/ko-->
+        </div>
+
         <form class="heidelpayUI form" novalidate>
             <div id="sepa-direct-debit-guaranteed-iban-field" class="field"></div>
             <div id="sepa-direct-debit-guaranteed-customer" class="field"></div>

--- a/view/frontend/web/template/payment/invoice_guaranteed.html
+++ b/view/frontend/web/template/payment/invoice_guaranteed.html
@@ -10,6 +10,12 @@
         <label class="label" data-bind="attr: {'for': getCode()}"><span data-bind="text: getTitle()"></span></label>
     </div>
     <div class="payment-method-content">
+        <div class="payment-method-billing-address">
+            <!-- ko foreach: $parent.getRegion(getBillingAddressFormName()) -->
+            <!-- ko template: getTemplate() --><!-- /ko -->
+            <!--/ko-->
+        </div>
+
         <form class="heidelpayUI form" novalidate>
             <div id="invoice-guaranteed-customer" class="field"></div>
             <div id="invoice-guaranteed-customer-error" class="field" style="color: #9f3a38"></div>

--- a/view/frontend/web/template/payment/invoice_guaranteed_b2b.html
+++ b/view/frontend/web/template/payment/invoice_guaranteed_b2b.html
@@ -10,6 +10,12 @@
         <label class="label" data-bind="attr: {'for': getCode()}"><span data-bind="text: getTitle()"></span></label>
     </div>
     <div class="payment-method-content">
+        <div class="payment-method-billing-address">
+            <!-- ko foreach: $parent.getRegion(getBillingAddressFormName()) -->
+            <!-- ko template: getTemplate() --><!-- /ko -->
+            <!--/ko-->
+        </div>
+
         <form class="heidelpayUI form" novalidate>
             <div id="invoice-guaranteed-b2b-customer" class="field"></div>
             <div id="invoice-guaranteed-b2b-customer-error" class="field" style="color: #9f3a38"></div>


### PR DESCRIPTION
The billing address may differ from the shipping address for many reasons so customers need to be able to change the billing address for guaranteed payment methods as these would otherwise throw errors.

This change adds the billing address change form to the guaranteed methods to allow for changing the billing address in these cases. 